### PR TITLE
improving how we test async logic

### DIFF
--- a/src/components/App/components/TodoList/components/TodoListItem/hooks/useTodoListItem/tests/useTodoListItem.test.tsx
+++ b/src/components/App/components/TodoList/components/TodoListItem/hooks/useTodoListItem/tests/useTodoListItem.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {useI18n} from '@shopify/react-i18n';
 import {TodoItem} from 'models';
 import {
-  asapPromise,
   HookPropsContainer,
   HookWrapper,
   mountWithContext,
@@ -175,7 +174,8 @@ describe('useTodoListItem()', () => {
   });
 
   it('invokes updateText when submit is called', async () => {
-    const updateText = jest.fn(noopPromise);
+    const updatePromise = Promise.resolve();
+    const updateText = jest.fn(() => updatePromise);
     const mockProps = {
       ...defaultMockProps,
       updateText,
@@ -188,13 +188,14 @@ describe('useTodoListItem()', () => {
         .triggerKeypath('fields.text.onChange', 'updated');
     });
     await wrapper.find(HookPropsContainer)!.trigger('submit');
-    await asapPromise();
+    await updatePromise;
 
     expect(updateText).toHaveBeenCalledTimes(1);
   });
 
   it('disables edit mode when submit is successful', async () => {
-    const updateText = jest.fn(noopPromise);
+    const updatePromise = Promise.resolve();
+    const updateText = jest.fn(() => updatePromise);
     const mockProps = {
       ...defaultMockProps,
       updateText,
@@ -207,7 +208,7 @@ describe('useTodoListItem()', () => {
         .triggerKeypath('fields.text.onChange', 'updated');
     });
     await wrapper.find(HookPropsContainer)!.trigger('submit');
-    await asapPromise();
+    await updatePromise;
 
     expect(wrapper).toContainReactComponent(HookPropsContainer, {
       isEditing: false,
@@ -215,7 +216,8 @@ describe('useTodoListItem()', () => {
   });
 
   it('resets the text field when submit is successful', async () => {
-    const updateText = jest.fn(noopPromise);
+    const updatePromise = Promise.resolve();
+    const updateText = jest.fn(() => updatePromise);
     const mockProps = {
       ...defaultMockProps,
       updateText,
@@ -228,7 +230,7 @@ describe('useTodoListItem()', () => {
         .triggerKeypath('fields.text.onChange', 'updated');
     });
     await wrapper.find(HookPropsContainer)!.trigger('submit');
-    await asapPromise();
+    await updatePromise;
 
     expect(wrapper).toContainReactComponent(HookPropsContainer, {
       fields: {text: expect.objectContaining({value: ''})},
@@ -251,7 +253,6 @@ describe('useTodoListItem()', () => {
         .triggerKeypath('fields.text.onChange', 'updated');
     });
     await wrapper.find(HookPropsContainer)!.trigger('submit');
-    await asapPromise();
 
     expect(wrapper).toContainReactComponent(HookPropsContainer, {
       error: ErrorType.Save,

--- a/src/components/App/components/TodoList/components/TodoListItem/tests/TodoListItem.test.tsx
+++ b/src/components/App/components/TodoList/components/TodoListItem/tests/TodoListItem.test.tsx
@@ -12,7 +12,7 @@ import {
   CircleTickMajorTwotone,
   EditMajorTwotone,
 } from '@shopify/polaris-icons';
-import {asapPromise, mountWithContext, noopPromise} from 'tests/utilities';
+import {mountWithContext, noopPromise} from 'tests/utilities';
 import {ErrorType} from '../hooks/useTodoListItem/useTodoListItem';
 import TodoListItem, {
   errorableAction,
@@ -175,7 +175,8 @@ describe('<TodoListItem />', () => {
 
   it('removes a newly created item when the Escape key is pressed in edit mode', async () => {
     const setRemoving = jest.fn();
-    const removeItem = jest.fn(noopPromise);
+    const removePromise = Promise.resolve();
+    const removeItem = jest.fn(() => removePromise);
     useTodoListItemMock.mockImplementation(() => ({
       ...mockUseTodoListItem(),
       isEditing: true,
@@ -189,7 +190,7 @@ describe('<TodoListItem />', () => {
     const wrapper = mountWithContext(<TodoListItem {...mockProps} />);
 
     await wrapper.find('div')!.trigger('onKeyDown', {key: 'Escape'});
-    await asapPromise();
+    await removePromise;
 
     expect(setRemoving).toHaveBeenCalledTimes(2);
     expect(setRemoving).toHaveBeenLastCalledWith(false);
@@ -232,7 +233,8 @@ describe('<TodoListItem />', () => {
   });
 
   it('toggles isCompleted when the <ResourceList.Item /> is clicked while not in edit mode', async () => {
-    const toggleComplete = jest.fn(noopPromise);
+    const togglePromise = Promise.resolve();
+    const toggleComplete = jest.fn(() => togglePromise);
     const setToggling = jest.fn();
     useTodoListItemMock.mockImplementation(() => ({
       ...mockUseTodoListItem(),
@@ -246,7 +248,7 @@ describe('<TodoListItem />', () => {
     const wrapper = mountWithContext(<TodoListItem {...mockProps} />);
 
     await wrapper.find(ResourceList.Item)!.trigger('onClick');
-    await asapPromise();
+    await togglePromise;
 
     expect(setToggling).toHaveBeenCalledTimes(2);
     expect(setToggling).toHaveBeenLastCalledWith(false);
@@ -268,14 +270,14 @@ describe('<TodoListItem />', () => {
     const wrapper = mountWithContext(<TodoListItem {...mockProps} />);
 
     await wrapper.find(ResourceList.Item)!.trigger('onClick');
-    await asapPromise();
 
     expect(setError).toHaveBeenCalledTimes(1);
     expect(setError).toHaveBeenLastCalledWith(ErrorType.Toggle);
   });
 
   it('ignores <ResourceList.Item /> clicks while in edit mode', async () => {
-    const toggleComplete = jest.fn(noopPromise);
+    const togglePromise = Promise.resolve();
+    const toggleComplete = jest.fn(() => togglePromise);
     const setToggling = jest.fn();
     useTodoListItemMock.mockImplementation(() => ({
       ...mockUseTodoListItem(),
@@ -289,7 +291,7 @@ describe('<TodoListItem />', () => {
     const wrapper = mountWithContext(<TodoListItem {...mockProps} />);
 
     await wrapper.find(ResourceList.Item)!.trigger('onClick');
-    await asapPromise();
+    await togglePromise;
 
     expect(setToggling).not.toHaveBeenCalled();
     expect(toggleComplete).not.toHaveBeenCalled();
@@ -488,7 +490,8 @@ describe('<TodoListItem />', () => {
   });
 
   it('invokes removeItem when the remove button is clicked', async () => {
-    const removeItem = jest.fn(noopPromise);
+    const removePromise = Promise.resolve();
+    const removeItem = jest.fn(() => removePromise);
     const setRemoving = jest.fn();
     const event = {
       preventDefault: jest.fn(),
@@ -507,7 +510,7 @@ describe('<TodoListItem />', () => {
     await wrapper
       .find(Button, {destructive: true, icon: 'delete'})!
       .trigger<any>('onClick', event);
-    await asapPromise();
+    await removePromise;
 
     expect(setRemoving).toHaveBeenCalledTimes(2);
     expect(setRemoving).toHaveBeenLastCalledWith(false);
@@ -533,7 +536,6 @@ describe('<TodoListItem />', () => {
     await wrapper
       .find(Button, {destructive: true, icon: 'delete'})!
       .trigger<any>('onClick');
-    await asapPromise();
 
     expect(setError).toHaveBeenCalledTimes(1);
     expect(setError).toHaveBeenLastCalledWith(ErrorType.Remove);
@@ -631,7 +633,7 @@ describe('errorableAction()', () => {
       ErrorType.Toggle,
       () => {},
       setInvoking,
-      asapPromise,
+      noopPromise,
     );
 
     expect(setInvoking).toHaveBeenCalledTimes(1);

--- a/src/tests/utilities.tsx
+++ b/src/tests/utilities.tsx
@@ -1,9 +1,10 @@
+/* istanbul ignore file */
+
 import React from 'react';
-import {act} from 'react-dom/test-utils';
 import {AppProvider, Frame} from '@shopify/polaris';
 import {I18n, I18nContext, TranslationDictionary} from '@shopify/react-i18n';
 import {I18nParentContext} from '@shopify/react-i18n/dist/context';
-import {createMount, CustomRoot} from '@shopify/react-testing';
+import {createMount} from '@shopify/react-testing';
 import {i18nManager} from 'utilities';
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {fallbackTranslations} from 'components/App/translations';
@@ -38,25 +39,6 @@ export const mountWithContext = createMount<Options, Context>({
   },
 });
 
-/**
- * mount an element that produces async side effects after mounting.
- * mounting will await on an asapPromise by default.
- */
-export async function mountWithContextAsync<Props>(
-  element: React.ReactElement<any>,
-  options?: Options,
-  mounted: () => Promise<any> = asapPromise,
-) {
-  let wrapper: CustomRoot<Props, Context>;
-
-  await (act as any)(async () => {
-    wrapper = mountWithContext<Props>(element, options);
-    await mounted();
-  });
-
-  return wrapper!;
-}
-
 interface HookWrapperProps {
   args?: any[];
   hook(...args: any[]): any;
@@ -89,5 +71,5 @@ export function noopPromise() {
  * code has executed.
  */
 export function asapPromise() {
-  return new Promise((resolve) => setImmediate(resolve));
+  return new Promise<any>((resolve) => setImmediate(resolve));
 }


### PR DESCRIPTION
the `asapPromise` strat was a work around for dealing with async rendering and logic in custom hooks. We can solve this work around using a shared `Promise` that is awaited by both the tested code and the testing code. This shared promise allows us to synchronise the test context on async behaviours. By leveraging this strategy we can also remove the workaround to mount components containing async behaviours in a `useEffect` handler (i.e., we can remove `mountWithAppContextAsync`).

NOTE: leaving in the `asapPromise` since it could still be useful, but the async mounter has no value any more.