### PR TITLE
updating CI for node v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,12 @@ jobs:
       - build
   node-11:
     docker:
-      - image: circleci/node:11.10
+      - image: circleci/node:11
+    steps:
+      - build
+  node-12:
+    docker:
+      - image: circleci/node:12
     steps:
       - build
 
@@ -65,3 +70,4 @@ workflows:
     jobs:
       - node-lts
       - node-11
+      - node-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 matrix:
   include:
+    - node_js: '12'
     - node_js: '11'
     - node_js: 'lts/*'
       env: UPLOAD_COVERALLS=yes


### PR DESCRIPTION
node v12 is a [current release](https://github.com/nodejs/Release#release-schedule) so we should be testing against it