### PR TITLE
fixing how cancel works with empty text

### DIFF
--- a/src/components/App/components/TodoList/components/TodoListItem/TodoListItem.tsx
+++ b/src/components/App/components/TodoList/components/TodoListItem/TodoListItem.tsx
@@ -75,13 +75,6 @@ export default function TodoListItem({
   const handleDismissToast = useCallback(() => {
     setError(null);
   }, [setError]);
-  const handleEdit = useCallback(
-    (event?: MouseEvent) => {
-      preventToggleEvent(event);
-      setIsEditing(!isEditing);
-    },
-    [setIsEditing, isEditing],
-  );
   const handleRemove = useCallback(
     (event?: MouseEvent) => {
       preventToggleEvent(event);
@@ -94,6 +87,17 @@ export default function TodoListItem({
       );
     },
     [isMounted, removeItem, setError, setRemoving],
+  );
+  const handleEdit = useCallback(
+    (event?: MouseEvent) => {
+      preventToggleEvent(event);
+      if (isEditing && !item.text) {
+        handleRemove();
+      } else {
+        setIsEditing(!isEditing);
+      }
+    },
+    [isEditing, item.text, handleRemove, setIsEditing],
   );
   const handleKeyDown = useCallback(
     ({key}: KeyboardEvent) => {

--- a/src/components/App/components/TodoList/components/TodoListItem/tests/TodoListItem.test.tsx
+++ b/src/components/App/components/TodoList/components/TodoListItem/tests/TodoListItem.test.tsx
@@ -450,7 +450,7 @@ describe('<TodoListItem />', () => {
     expect(event.stopPropagation).toHaveBeenCalledTimes(1);
   });
 
-  it('disables edit mode when the cancel button is clicked', () => {
+  it('disables edit mode when the cancel button is clicked for an existing item', () => {
     const setIsEditing = jest.fn();
     const event = {
       preventDefault: jest.fn(),
@@ -472,6 +472,46 @@ describe('<TodoListItem />', () => {
 
     expect(setIsEditing).toHaveBeenCalledTimes(1);
     expect(setIsEditing).toHaveBeenCalledWith(false);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes a new item when the cancel button is clicked', async () => {
+    const removePromise = Promise.resolve();
+    const removeItem = jest.fn(() => removePromise);
+    const event = {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+    };
+    const mock = mockUseTodoListItem();
+    useTodoListItemMock.mockImplementation(() => ({
+      ...mock,
+      fields: {
+        text: {
+          ...mock.fields.text,
+          defaultValue: '',
+          value: '',
+        },
+      },
+      isEditing: true,
+    }));
+    const mockProps = {
+      ...defaultMockProps,
+      item: {
+        id: '1',
+        isComplete: false,
+        text: '',
+      },
+      removeItem,
+    };
+    const wrapper = mountWithContext(<TodoListItem {...mockProps} />);
+
+    await wrapper
+      .find(Button, {primary: false, icon: 'cancel'})!
+      .trigger<any>('onClick', event);
+    await removePromise;
+
+    expect(removeItem).toHaveBeenCalledTimes(1);
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(event.stopPropagation).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
When you cancel an edit of a newly created field, the automated behaviour automatically returns to edit mode (because its default value is empty and therefore must be edited). The UX for this behaviour is a bit off putting. Instead we will remove the item on cancel.